### PR TITLE
郵便番号詳細エンドポイント作成

### DIFF
--- a/backend/pkg/handlers/detailHandler.go
+++ b/backend/pkg/handlers/detailHandler.go
@@ -1,10 +1,62 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 )
 
+type PostcodeDetail struct {
+    Postcode        string `json:"new"`
+    Prefecture      string `json:"prefecture"`
+    PrefectureKana  string `json:"prefecture_kana"`
+    PrefectureRoman string `json:"prefecture_roman"`
+    City            string `json:"city"`
+    CityKana        string `json:"city_kana"`
+    CityRoman       string `json:"city_roman"`
+    Suburb          string `json:"suburb"`
+    SuburbKana      string `json:"suburb_kana"`
+    SuburbRoman     string `json:"suburb_roman"`
+    StreetAddress   string `json:"street_address"` // 1008066 のとき"１丁目３−７"が入る
+}
+
 func DetailHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello World, from DetailHandler!")
+	// パラメータを取得
+	query := r.URL.Query()
+    postcode := query.Get("postcode")
+	// TODO: パラメータのバリデーション追加(7桁の数字のみ許可)
+
+	// postcodeを使ってAPIを叩く
+	url := fmt.Sprintf("https://postcode.teraren.com/postcodes/%s.json", postcode)
+	res, err := http.Get(url)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		fmt.Println("Error:", postcode, "という郵便番号は存在しません | status code", res.StatusCode)
+		return
+	}
+	body, _ := io.ReadAll(res.Body)
+
+	// レスポンスを構造体に変換
+	var postcodeDetail PostcodeDetail
+
+	if err := json.Unmarshal(body, &postcodeDetail); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// 構造体をjsonに変換
+	p, err := json.Marshal(postcodeDetail)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, "%s", p)
 }


### PR DESCRIPTION
関連issue #3 

やったこと

- 郵便番号詳細API作成
  - 受け取った数字の郵便番号をポストくんAPIで検索する
  - そのレスポンスを構造体`PostcodeDetail`に格納
  - その構造体をjsonに変換しレスポンスとして返す

次やること
- パラメータのバリデーション追加(7桁の数字のみ許可)

動作確認

サーバーを起動し`http://localhost:8000/api/detail?postcode=2020012`をブラウザで打つと下記のjsonが表示されること

<img width="552" alt="スクリーンショット 2024-04-14 12 40 23" src="https://github.com/teamA-recursion-202404/golang_zipcode_api/assets/75294723/03cf8c5f-6f3b-46f7-8e98-2d7282ba5aba">
