### PR TITLE
go.modの修正

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
-module example.com/zipcode_api_202304
+module github.com/teamA-recursion-202404/golang_postcode_api
 
 go 1.21.6

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"example.com/zipcode_api_202304/pkg/handlers"
+	"github.com/teamA-recursion-202404/golang_postcode_api/pkg/handlers"
 )
 
 func main() {


### PR DESCRIPTION
やったこと

- `zipcode`の表記をなくすためにgo.modの作り直しを行いました
  - 作り直した根拠　「リポジトリ名を間違えたらgo.mod消してもう一度やり直したら良さそう」https://zenn.dev/optimisuke/articles/105feac3f8e726830f8c#go-mod-init
- 新たな文字列の根拠としては前回のBチームのgo.modを参考にしました
- このファイルの1行目 https://github.com/Recursion-teamB-create-webAPI/Golang-Web-API/blob/main/Backend/go.mod

