### PR TITLE
エラーをjsonで返す

### DIFF
--- a/backend/pkg/handlers/detailHandler.go
+++ b/backend/pkg/handlers/detailHandler.go
@@ -21,11 +21,17 @@ type PostcodeDetail struct {
     StreetAddress   string `json:"street_address"` // 1008066 のとき"１丁目３−７"が入る
 }
 
+type ErrorMessage struct {
+	StatusCode  int    `json:"status code"`
+	Message     string `json:"message"`
+}
+
 func DetailHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
 	// パラメータを取得
 	query := r.URL.Query()
     postcode := query.Get("postcode")
-	// TODO: パラメータのバリデーション追加(7桁の数字のみ許可)
 
 	// postcodeを使ってAPIを叩く
 	url := fmt.Sprintf("https://postcode.teraren.com/postcodes/%s.json", postcode)
@@ -36,8 +42,17 @@ func DetailHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
-		fmt.Println("Error:", postcode, "という郵便番号は存在しません | status code", res.StatusCode)
+	// 不正な郵便番号の場合、その旨を返す
+	if res.StatusCode == 404 {
+		json.NewEncoder(w).Encode(
+			ErrorMessage{Message:  postcode + " という郵便番号は存在しません。正しい郵便番号を入力してください", StatusCode: 404},
+		)
+		return
+	// それ以外のエラーの場合、単純なエラーメッセージを返す
+	} else if res.StatusCode != 200 {
+		json.NewEncoder(w).Encode(
+			ErrorMessage{Message: "エラーが発生しました", StatusCode: res.StatusCode},
+		)
 		return
 	}
 	body, _ := io.ReadAll(res.Body)
@@ -51,12 +66,5 @@ func DetailHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 構造体をjsonに変換
-	p, err := json.Marshal(postcodeDetail)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, "%s", p)
+	json.NewEncoder(w).Encode(postcodeDetail)
 }

--- a/backend/pkg/handlers/detailHandler.go
+++ b/backend/pkg/handlers/detailHandler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 )
 
 type PostcodeDetail struct {
@@ -26,12 +27,25 @@ type ErrorMessage struct {
 	Message     string `json:"message"`
 }
 
+func isNumericString(s string) bool {
+    _, err := strconv.Atoi(s)
+    return err == nil
+}
+
 func DetailHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	// パラメータを取得
 	query := r.URL.Query()
     postcode := query.Get("postcode")
+
+	// postcode が7桁の数字でない場合、エラーメッセージを返す
+	if len(postcode) != 7 || !isNumericString(postcode) {
+		json.NewEncoder(w).Encode(
+			ErrorMessage{Message: "7桁の数字を入力してください", StatusCode: 400},
+		)
+		return
+	}
 
 	// postcodeを使ってAPIを叩く
 	url := fmt.Sprintf("https://postcode.teraren.com/postcodes/%s.json", postcode)

--- a/backend/pkg/handlers/detailHandler.go
+++ b/backend/pkg/handlers/detailHandler.go
@@ -22,7 +22,7 @@ type PostcodeDetail struct {
 }
 
 type ErrorMessage struct {
-	StatusCode  int    `json:"status code"`
+	StatusCode  int    `json:"status_code"`
 	Message     string `json:"message"`
 }
 


### PR DESCRIPTION
#3 

### やったこと

- `ErrorMessage`型を作り、リクエストされた郵便番号が存在しないときなどにその型を使ってjsonでレスポンスを返すようにしました
  - 理由：　正常時・エラー時ともにjsonでレスポンスを返すようにしたほうがよいみたいです
- バリデーション追加（7桁の数字でなければポストくんにアクセスせずにエラーを返す）



---

before

レスポンスとしては何も返しておらず、ターミナルにメッセージが表示されるだけだった

<img width="535" alt="スクリーンショット 2024-04-18 10 01 48" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/de9f258f-27ff-4302-a86c-affbdbe6e102">

![スクリーンショット 2024-04-18 10 01 59](https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/cdba229d-60b4-48e9-bc41-280292bfd11b)



after

7桁の数字でないとき

<img width="497" alt="スクリーンショット 2024-04-18 19 10 32" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/7f3822a8-98f8-4425-bc58-a3e5db76d6e6">


7桁の数字だが存在しない番号のとき

<img width="538" alt="スクリーンショット 2024-04-18 19 11 09" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/bceaa566-0586-497c-8985-6a9700ca1604">


