### PR TITLE
[Go] postcodeの型を統一

### DIFF
--- a/backend/pkg/handlers/detailHandler.go
+++ b/backend/pkg/handlers/detailHandler.go
@@ -10,20 +10,6 @@ import (
 	"github.com/teamA-recursion-202404/golang_postcode_api/pkg/structs"
 )
 
-type PostcodeDetail struct {
-    Postcode        string `json:"new"`
-    Prefecture      string `json:"prefecture"`
-    PrefectureKana  string `json:"prefecture_kana"`
-    PrefectureRoman string `json:"prefecture_roman"`
-    City            string `json:"city"`
-    CityKana        string `json:"city_kana"`
-    CityRoman       string `json:"city_roman"`
-    Suburb          string `json:"suburb"`
-    SuburbKana      string `json:"suburb_kana"`
-    SuburbRoman     string `json:"suburb_roman"`
-    StreetAddress   string `json:"street_address"` // 1008066 のとき"１丁目３−７"が入る
-}
-
 func isNumericString(s string) bool {
     _, err := strconv.Atoi(s)
     return err == nil
@@ -72,7 +58,7 @@ func DetailHandler(w http.ResponseWriter, r *http.Request) {
 	body, _ := io.ReadAll(res.Body)
 
 	// レスポンスを構造体に変換
-	var postcodeDetail PostcodeDetail
+	var postcodeDetail structs.Postcode
 
 	if err := json.Unmarshal(body, &postcodeDetail); err != nil {
 		fmt.Println(err)

--- a/backend/pkg/handlers/listHandler.go
+++ b/backend/pkg/handlers/listHandler.go
@@ -6,22 +6,9 @@ import (
 	"io"
 	"net/http"
 	"sort"
+
+	"github.com/teamA-recursion-202404/golang_postcode_api/pkg/structs"
 )
-
-// レスポンスをjsonに変換するための構造体
-// 参考: https://randomuser.me/documentation#results
-type ResponseList struct {
-	Results []Postcode `json:"results"`
-}
-
-type Postcode struct {
-	Jis        string `json:"jis"`
-	OldZip     string `json:"old"`
-	Zip        string `json:"new"`
-	Prefecture string `json:"prefecture"`
-	City       string `json:"city"`
-	Suburb     string `json:"suburb"`
-}
 
 func ListHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -45,7 +32,7 @@ func ListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var postcodes []Postcode
+	var postcodes []structs.Postcode
 	err = json.Unmarshal(body, &postcodes)
 	if err != nil {
 		return
@@ -54,21 +41,21 @@ func ListHandler(w http.ResponseWriter, r *http.Request) {
 	// asc or desc が指定されていたらソートする
 	sortPostcodes(postcodes, sortOrder)
 
-	err = json.NewEncoder(w).Encode(ResponseList{Results: postcodes})
+	err = json.NewEncoder(w).Encode(structs.ResponseList{Results: postcodes})
 	if err != nil {
 		http.Error(w, "Failed to encode JSON", http.StatusInternalServerError)
 		return
 	}
 }
 
-func sortPostcodes(postcodes []Postcode, sortOrder string) {
+func sortPostcodes(postcodes []structs.Postcode, sortOrder string) {
 	if sortOrder == "asc" {
 		sort.Slice(postcodes, func(i, j int) bool {
-			return postcodes[i].Zip < postcodes[j].Zip
+			return postcodes[i].Postcode < postcodes[j].Postcode
 		})
 	} else if sortOrder == "desc" {
 		sort.Slice(postcodes, func(i, j int) bool {
-			return postcodes[i].Zip > postcodes[j].Zip
+			return postcodes[i].Postcode > postcodes[j].Postcode
 		})
 	}
 }

--- a/backend/pkg/handlers/searchHandler.go
+++ b/backend/pkg/handlers/searchHandler.go
@@ -9,16 +9,6 @@ import (
 	"github.com/teamA-recursion-202404/golang_postcode_api/pkg/structs"
 )
 
-type postcode struct {
-	Jis        string `json:"jis"`
-	OldZip     string `json:"old"`
-	Zip        string `json:"new"`
-	Prefecture string `json:"prefecture"`
-	City       string `json:"city"`
-	Suburb     string `json:"suburb"`
-}
-
-
 func SearchHandler(w http.ResponseWriter, r *http.Request) {
 	// "*" はワイルドカードで、どのドメインからのリクエストも許可する
 	// 本番環境ではセキュリティ上の理由から設定しないことが推奨される
@@ -36,10 +26,7 @@ func SearchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// keywordが複数の場合、それを検索できるように整える
-	//   ポストくんが受け付ける複数検索の形式は以下の通り
-	//   ?keyword=東京+渋谷+恵比寿ガーデンプレイス
-
+	// 備考: keywordが複数の場合でも自動的に複数語句で検索される
 	response, err := http.Get("https://postcode.teraren.com/postcodes.json?s=" + keyword)
 
 	if err != nil {
@@ -54,11 +41,11 @@ func SearchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var postcodes []postcode
+	var postcodes []structs.Postcode
 	err = json.Unmarshal(body, &postcodes)
 	if err != nil {
 		return
 	}
 
-	json.NewEncoder(w).Encode(postcodes)
+	json.NewEncoder(w).Encode(structs.ResponseList{Results: postcodes})
 }

--- a/backend/pkg/structs/structs.go
+++ b/backend/pkg/structs/structs.go
@@ -4,3 +4,23 @@ type ErrorMessage struct {
 	StatusCode  int    `json:"status_code"`
 	Message     string `json:"message"`
 }
+
+type Postcode struct {
+    Postcode        string `json:"new"`
+    Prefecture      string `json:"prefecture"`
+    PrefectureKana  string `json:"prefecture_kana"`
+    PrefectureRoman string `json:"prefecture_roman"`
+    City            string `json:"city"`
+    CityKana        string `json:"city_kana"`
+    CityRoman       string `json:"city_roman"`
+    Suburb          string `json:"suburb"`
+    SuburbKana      string `json:"suburb_kana"`
+    SuburbRoman     string `json:"suburb_roman"`
+    StreetAddress   string `json:"street_address"` // 1008066 のとき"１丁目３−７"が入る
+}
+
+// レスポンスをjsonに変換するための構造体
+// 参考: https://randomuser.me/documentation#results
+type ResponseList struct {
+	Results []Postcode `json:"results"`
+}


### PR DESCRIPTION
 こちら急ぎのため自分でマージしたいと思います

---

以下の3つのファイルに分かれていた型を`structs.go`ファイルのPostcode型として統一しました

listHandlerの`Postcode`型
searchHandlerの`Postcode`型
detailHandlerの`PostcodeDetail`型

動作確認

3つのapiが問題なく作動すること
<img width="472" alt="スクリーンショット 2024-04-21 17 53 18" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/0c8d3d05-4b84-4301-a030-e314ef1c9f21">

<img width="690" alt="スクリーンショット 2024-04-21 17 53 06" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/2db80b04-690d-4813-a83b-174d3a42b5e7">

<img width="526" alt="スクリーンショット 2024-04-21 17 53 44" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/ddb348c3-2207-4799-a39a-db7bd2e785e4">
