### PR TITLE
[Go]リスト表示・page番号のバリデーション追加

### DIFF
--- a/backend/pkg/handlers/listHandler.go
+++ b/backend/pkg/handlers/listHandler.go
@@ -6,17 +6,34 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"strconv"
 
 	"github.com/teamA-recursion-202404/golang_postcode_api/pkg/structs"
 )
 
 func ListHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	query := r.URL.Query()
 	page := query.Get("page")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	sortOrder := query.Get("sort") // 変数名sortは不可っぽい ライブラリの名前とかぶるため
+
+	i, err := strconv.Atoi(page)
+	// page が数字でない場合、エラーメッセージを返す
+	if err != nil {
+		json.NewEncoder(w).Encode(
+			structs.ErrorMessage{Message: "ページ番号には数字を入力してください", StatusCode: 400},
+		)
+		return
+	}
+	// page が1210以上の場合、エラーメッセージを返す
+	if i >= 1210 {
+		json.NewEncoder(w).Encode(
+			structs.ErrorMessage{Message: "リスト表示のページ番号には 1209 以下の数字を入力してください", StatusCode: 400},
+		)
+		return
+	}
 
 	response, err := http.Get("https://postcode.teraren.com/postcodes.json?page=" + page)
 


### PR DESCRIPTION
やったこと

* リスト表示・page番号のバリデーション追加
  * 文字列の場合
  * 1210以上のページが指定された場合

動作確認

### 文字列の場合

before
pageパラメータは無視して、1ページ目が返ってきていた
<img width="1016" alt="スクリーンショット 2024-04-23 19 45 31" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/a9560daa-4dc2-410e-8b6b-cd12153d20e6">

after
<img width="512" alt="スクリーンショット 2024-04-23 19 46 49" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/090df548-9e9b-41a8-9cb0-d5045a4f844e">

### 1210以上の場合

before
<img width="464" alt="スクリーンショット 2024-04-23 19 45 52" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/7eee2c9f-2b0e-4faa-9727-ccc13b3fcada">

after
<img width="589" alt="スクリーンショット 2024-04-23 19 46 32" src="https://github.com/teamA-recursion-202404/golang_postcode_api/assets/75294723/653e0ea3-ff8d-462a-97a1-6db6beac346a">
